### PR TITLE
~/.polymorph dir  //WIP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 __pycache__/*g
 *~
 .DS_Store
+*.egg-info

--- a/polymorph/UI/interface.py
+++ b/polymorph/UI/interface.py
@@ -11,7 +11,7 @@ from polymorph.utils import get_arpspoofer
 from polymorph.UI.command_parser import CommandParser
 from collections import OrderedDict
 import os
-from os.path import dirname
+# from os.path import dirname
 import polymorph
 
 
@@ -21,7 +21,7 @@ class Interface(object):
 
     def __init__(self):
         self._poisoner = None
-        self._polym_path = dirname(polymorph.__file__)
+        self._polym_path = polymorph.settings.path
 
     @staticmethod
     def print_help(hdict):

--- a/polymorph/UI/tlistinterface.py
+++ b/polymorph/UI/tlistinterface.py
@@ -14,7 +14,7 @@ from polymorph.deps.prompt_toolkit.completion import WordCompleter
 from polymorph.deps.prompt_toolkit.auto_suggest import AutoSuggestFromHistory
 from polymorph.deps.prompt_toolkit.shortcuts import CompleteStyle
 import polymorph
-from os.path import dirname, join
+from os.path import join
 
 
 class TListInterface(Interface):
@@ -37,7 +37,7 @@ class TListInterface(Interface):
         # Class Attributes
         self._t = tlist
         self._poisoner = poisoner
-        self._polym_path = dirname(polymorph.__file__)
+        self._polym_path = polymorph.settings.path
 
     def run(self):
         """Runs the interface and waits for user input commands."""

--- a/polymorph/__init__.py
+++ b/polymorph/__init__.py
@@ -1,1 +1,4 @@
+from .settings import Settings
 
+# PoC to create initial settings manager
+settings = Settings()

--- a/polymorph/settings.py
+++ b/polymorph/settings.py
@@ -1,0 +1,16 @@
+import os
+
+class Settings (object):
+
+    def __init__(self):
+        self._poisoner = None
+        self.path = os.path.expanduser("~/.polymorph")
+
+        # TODO; Just a PoC with hardcoded dirs, integrate some kind of settings
+        # TODO; Ensure that all App reuse this iface._polym_path instead of redefine it
+        # Iterate all paths down the "~/.polymorph" to initialize it if needed
+        _conditions_path = ["", "conditions", "conditions/executions", "conditions/postconditions", "conditions/preconditions"]
+        for _path in _conditions_path:
+            _full_path = "{}/{}".format(self.path, _path)
+            if not os.path.exists(_full_path):
+                os.makedirs(_full_path)

--- a/polymorph/settings.py
+++ b/polymorph/settings.py
@@ -6,11 +6,16 @@ class Settings (object):
         self._poisoner = None
         self.path = os.path.expanduser("~/.polymorph")
 
-        # TODO; Just a PoC with hardcoded dirs, integrate some kind of settings
+        self.paths = {
+            "": self.path,
+            "conditions": "{}/conditions".format(self.path),
+            "preconditions": "{}/conditions/preconditions".format(self.path),
+            "postconditions": "{}/conditions/postconditions".format(self.path),
+            "executions": "{}/conditions/executions".format(self.path),
+            "templates": "{}/templates".format(self.path),
+        }
+
         # TODO; Ensure that all App reuse this iface._polym_path instead of redefine it
-        # Iterate all paths down the "~/.polymorph" to initialize it if needed
-        _conditions_path = ["", "conditions", "conditions/executions", "conditions/postconditions", "conditions/preconditions"]
-        for _path in _conditions_path:
-            _full_path = "{}/{}".format(self.path, _path)
-            if not os.path.exists(_full_path):
-                os.makedirs(_full_path)
+        for _path in self.paths.values():
+            if not os.path.exists(_path):
+                os.makedirs(_path)

--- a/polymorph/template.py
+++ b/polymorph/template.py
@@ -16,7 +16,7 @@ from os.path import dirname
 import polymorph.conditions
 from os import listdir
 from os.path import isfile, join
-
+from polymorph import settings
 
 class Template:
     """Main class that represents a template"""
@@ -47,7 +47,7 @@ class Template:
         if from_path:
             self.read(from_path)
         # Path to conditions (precs, execs, posts)
-        self._conds_path = dirname(polymorph.conditions.__file__)
+        self._conds_path = dirname(settings.paths['conditions'])
 
     def __repr__(self):
         return "<template.Template: %s>" % "/".join(self.layernames())
@@ -67,7 +67,13 @@ class Template:
         """
         if not path:
             path = "../templates/" + self._name.replace("/", "_") + ".json"
-        with open(path, 'w') as outfile:
+
+        if not path.endswith(".json"):
+            path += ".json"
+
+        template_file = "{}/{}".format(settings.paths['templates'], path)
+
+        with open(template_file, 'w') as outfile:
             json.dump(self.dict(), outfile, indent=4)
 
     @property
@@ -213,7 +219,7 @@ class Template:
         """
         self.del_function('executions', name)
 
-    def get_function_source(self, func, name):
+    def get_function_source(self, cond, name):
         """Returns a precondition/postcondition/execution source code.
 
         Parameters
@@ -229,7 +235,7 @@ class Template:
             Source code of the function.
 
         """
-        path = "%s/%s/%s.py" % (self._conds_path, func, name)
+        path = join(settings.paths[cond], "{}.py".format(name))
         if os.path.isfile(path):
             return open(path).read()
         return "[!] File is not in disk"
@@ -581,7 +587,8 @@ class Template:
         def print_source(cond, n):
             print(colored(n, 'cyan'))
             print(self.get_function_source(cond, n))
-            
+
+        _cond_path = settings.paths[cond]
         cond_names = list(self._functions[cond])
         if name and name in cond_names and verbose:
             print_source(cond, name)
@@ -606,9 +613,10 @@ class Template:
             conditions.
 
         """
+        _cond_path = settings.paths[cond]
         cond_names = [f[:-3]
-                      for f in listdir(join(self._conds_path, cond))
-                      if isfile(join(join(self._conds_path, cond), f))
+                      for f in listdir(_cond_path)
+                      if isfile(join(_cond_path, f))
                       and f != "__init__.py"
                       and f[-3:] == ".py"]
         if verbose:

--- a/polymorph/utils.py
+++ b/polymorph/utils.py
@@ -13,8 +13,41 @@ from polymorph.interceptor import Interceptor
 import platform
 import polymorph
 from os.path import dirname, join
+import imp, os, importlib
 
 POLYM_PATH = dirname(polymorph.__file__)
+
+
+def import_file(filename, module=""):
+    """
+    old stuff just for debug purposes
+    # m = importlib.import_module(
+    #     "polymorph.conditions.%s.%s" % (settings.paths[cond], name))
+    # importlib.reload(m)
+
+    """
+    module = None
+
+    try:
+        # Get module name and path from full path
+        module_dir, module_file = os.path.split(filename)
+        module_name, module_ext = os.path.splitext(module_file)
+
+        # Get module "spec" from filename
+        spec = importlib.util.spec_from_file_location(module_name,filename)
+
+        module = spec.loader.load_module()
+
+    except Exception as ec:
+        # TODO validate py2 importing if needed @shramos
+        print(ec)
+
+    finally:
+        return module
+
+    with open(filename, "r") as f:
+        return imp.load_module(module, f, filename, "")
+
 
 def capture(userfilter="", pcapname=".tmp.pcap", func=None, count=0, time=None):
     """This function is a wrapper function above the sniff scapy function. The
@@ -144,7 +177,7 @@ def set_ip_forwarding(value):
             file.write(str(value))
             file.close()
 
-        
+
 def get_arpspoofer(targets, gateway, iface=None, gatewaymac=None,
           ignore=None, arpmode='rep', mac=None, ip=None):
     # Creating a poison object
@@ -154,4 +187,3 @@ def get_arpspoofer(targets, gateway, iface=None, gatewaymac=None,
     poisoner = ARPpoisoner(poison)
     # return the poisoner
     return poisoner
-


### PR DESCRIPTION
# Use ~/.polymorph dir

// Do not merge, the idea is to integrate it into a devel branch and keep working on it, but I can just PR to master.

This improves `Polymorph` to be able to store all files (conditions, templates, temps, ...) inside a `$home` based polymorph directory.

By default this points to `~/.polymorph`, and at init time it ensures that the needed structure exists

In this case, we validate:
```
- ~/.polymorph
- ~/.polymorph/conditions
- ~/.polymorph/templates
- ~/.polymorph/conditions/executions
- ~/.polymorph/conditions/postconditions
- ~/.polymorph/conditions/preconditions
```

New `settings` class supports us to set library based properties and prerequisites.

It adapts all IO operations to use new settings.paths

It also provides a new way to perform hot module loading based on the imp library, see new method `utils.import_file`

Additionally, templates save process ensures that .json extension is included, and dumps the template to the templates folder `~/.polymorph/templates`.

-----------------------

WIP, some things to do
- [ ] validate and test using all support py versions (2.7, 3.4, 3.6, 3.7, ...)
- [ ] review pcap creation and loading
- [ ] analyze other possible IO
- [ ] test Windows, MacOS, ...
- [ ] manage lack of permisions to write on home
  - go to /tmp?

-----------------------

Will fix #1 