### PR TITLE
Dockerfiles update

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM kalilinux/kali-linux-docker
+FROM kalilinux/kali
 # Metadata params
 ARG BUILD_DATE
 ARG VERSION
@@ -19,8 +19,8 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.url='https://www.kali.org/' \
       org.label-schema.vendor='Offensive Security' \
       org.label-schema.schema-version='1.0' \
-      org.label-schema.docker.cmd='docker run --rm kalilinux/kali-linux-docker' \
-      org.label-schema.docker.cmd.devel='docker run --rm -ti kalilinux/kali-linux-docker' \
+      org.label-schema.docker.cmd='docker run --rm kalilinux/kali' \
+      org.label-schema.docker.cmd.devel='docker run --rm -ti kalilinux/kali' \
       org.label-schema.docker.debug='docker logs $CONTAINER' \
       io.github.offensive-security.docker.dockerfile="Dockerfile" \
       io.github.offensive-security.license="GPLv3" \
@@ -34,6 +34,8 @@ RUN set -x \
     && apt-get clean \
     && apt-get install -yqq build-essential python-dev libnetfilter-queue-dev tshark tcpdump python3-pip wireshark \
     && apt install -yqq python3-pip \
+    && apt install -yqq git \
+    && pip3 install -U git+https://github.com/kti/python-netfilterqueue \
     && pip3 install --process-dependency-links polymorph
 
 RUN apt-get install -yqq linux-image; exit 0

--- a/docker/Dockerfile-victim
+++ b/docker/Dockerfile-victim
@@ -1,4 +1,4 @@
-FROM kalilinux/kali-linux-docker
+FROM kalilinux/kali
 # Metadata params
 ARG BUILD_DATE
 ARG VERSION
@@ -17,8 +17,8 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
       org.label-schema.url='https://www.kali.org/' \
       org.label-schema.vendor='Offensive Security' \
       org.label-schema.schema-version='1.0' \
-      org.label-schema.docker.cmd='docker run --rm kalilinux/kali-linux-docker' \
-      org.label-schema.docker.cmd.devel='docker run --rm -ti kalilinux/kali-linux-docker' \
+      org.label-schema.docker.cmd='docker run --rm kalilinux/kali' \
+      org.label-schema.docker.cmd.devel='docker run --rm -ti kalilinux/kali' \
       org.label-schema.docker.debug='docker logs $CONTAINER' \
       io.github.offensive-security.docker.dockerfile="Dockerfile" \
       io.github.offensive-security.license="GPLv3" \
@@ -30,7 +30,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN set -x \
     && apt-get -yqq update \
     && apt-get clean
-RUN apt-get -yqq install gnupg gnupg2 
+RUN apt-get -yqq install gnupg gnupg2 wget
 RUN wget http://repo.mosquitto.org/debian/mosquitto-repo.gpg.key
 RUN apt-key add mosquitto-repo.gpg.key
 RUN echo "deb http://repo.mosquitto.org/debian jessie main" > /etc/apt/sources.list.d/mosquitto.list


### PR DESCRIPTION
Hi,
the Dockerfiles of polymorph have been updated since the used image is no longer available via docker-hub:
> Please note, kalilinux/kali-linux-docker is the former official image, it’s no longer updated. Don’t use it. [source](https://www.kali.org/docs/containers/official-kalilinux-docker-images/)


Please find attached the updated Dockerfiles with the new base image and the necessary adjustment for using python-netfilterqueue.

Dear @shramos, please check if could be useful :-)